### PR TITLE
import error with 'app' vs 'App', which was preventing heroku deployment

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import App from '../react/containers/App'
+import App from '../react/containers/app'
 
 document.addEventListener('DOMContentLoaded', () => {
   let reactElement = document.getElementById('app')

--- a/app/javascript/react/containers/app.js
+++ b/app/javascript/react/containers/app.js
@@ -9,4 +9,4 @@ const App = (props) => {
   );
 }
 
-export default App;
+export default app;

--- a/app/javascript/react/containers/app.js
+++ b/app/javascript/react/containers/app.js
@@ -9,4 +9,4 @@ const App = (props) => {
   );
 }
 
-export default app;
+export default App;


### PR DESCRIPTION
app.js was being referenced as App.js, Previously we would keep renaming it but git wouldn't update case change for some reason, so instead we just altered the import path in the application.js file. 